### PR TITLE
Add open source license, attribution, etc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Richard Barton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Converts a simple map recorded as a JSON object into a conventional visual form 
 [Example html map](https://cioportfolio.github.io/swardley-script/map.html) generated from the included map.js
 
 [jsfiddle version](https://jsfiddle.net/74jx2zog/) allows you to modify the example map online
+
+Wardley Mapping courtesy of Simon Wardley, CC BY-SA 4.0. To learn more about mapping, see [Simon's book](https://medium.com/wardleymaps/on-being-lost-2ef5f05eb1ec).


### PR DESCRIPTION
Hello, Richard!

I would like to use this code in another prototype I'm building, and I realized there isn't a license committed to the repo. So I thought I'd add one, or at least start a discussion about it.

What I've done here is add attribution to Simon and licensing info specifically for Wardley Mapping, and then added an MIT license for the software itself, which uses Wardley Mapping but is not an extension of it. (I think that's a reasonable interpretation, given [this thread](https://twitter.com/swardley/status/832098931622371328) on the subject of licensing.)

If you prefer a different license than MIT, by all means please feel welcome to replace it. Or if you wish to reserve all rights to it, please let us know! Thank you!